### PR TITLE
Fix the output for Object

### DIFF
--- a/log-timestamp.js
+++ b/log-timestamp.js
@@ -12,5 +12,5 @@ function patch(fn) {
 
 // the default date format to print
 function timestamp() {
-  return '[' + new Date().toISOString() + '] %s';
+  return '[' + new Date().toISOString() + ']';
 }


### PR DESCRIPTION
I fixed the output of a following case.

```javascript
require('log-timestamp');
console.log({foo: 'bar'});
// Output like this: [2015-01-14T03:01:15.925Z] [object Object]
```