### PR TITLE
improved readability

### DIFF
--- a/log-timestamp.js
+++ b/log-timestamp.js
@@ -12,5 +12,5 @@ function patch(fn) {
 
 // the default date format to print
 function timestamp() {
-  return '[' + new Date().toISOString() + ']';
+  return '[' + new Date().toISOString().slice(0,19).replace('T', ' ') + ']';
 }


### PR DESCRIPTION
It's a simple one-liner to improve the readability of the timestamp. Found myself pretty annoyed by the `T`, `Z` and the milliseconds. 
